### PR TITLE
pydantic 2.1.1 compat with deprecations

### DIFF
--- a/fastapi_csrf_protect/load_config.py
+++ b/fastapi_csrf_protect/load_config.py
@@ -8,7 +8,7 @@
 #
 # HISTORY:
 # *************************************************************
-from typing import Optional, Sequence
+from typing import Optional, Set
 from pydantic import BaseModel, validator, StrictBool, StrictInt, StrictStr
 
 
@@ -23,7 +23,7 @@ class LoadConfig(BaseModel):
     header_type: Optional[StrictStr] = None
     httponly: Optional[StrictBool] = True
     max_age: Optional[StrictInt] = 3600
-    methods: Optional[Sequence[StrictStr]] = {"POST", "PUT", "PATCH", "DELETE"}
+    methods: Optional[Set[StrictStr]] = {"POST", "PUT", "PATCH", "DELETE"}
     secret_key: Optional[StrictStr] = None
 
     @validator("methods", each_item=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 python = "^3.7"
 fastapi = "^0"
 itsdangerous = ">=2.0.1,<3.0.0"
-pydantic = ">=1.7.2,<2.0.0"
+pydantic = ">=1.7.2,<3.0.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"


### PR DESCRIPTION
MInimal code modifications to pass tests.

Main reason for the patch is pydantic `@validator` decorator was deprecated and now `each_item` parameter not support `Sequence` type now (sets, lists etc. required). 