### PR TITLE
Use form method instead of reading request body

### DIFF
--- a/fastapi_csrf_protect/load_config.py
+++ b/fastapi_csrf_protect/load_config.py
@@ -57,6 +57,6 @@ class LoadConfig(BaseModel):
         token_location: str = values.get("token_location", "header")
         if token_location == "body" and value is None:
             raise ValueError(
-                'The "body_key" must be present when "token_location" is "body"'
+                'The "token_key" must be present when "token_location" is "body"'
             )
         return value

--- a/poetry.lock
+++ b/poetry.lock
@@ -333,6 +333,17 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.6"
+description = "A streaming multipart parser for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+dev = ["atomicwrites (==1.2.1)", "attrs (==19.2.0)", "coverage (==6.5.0)", "hatch", "invoke (==1.7.3)", "more-itertools (==4.3.0)", "pbr (==4.3.0)", "pluggy (==1.0.0)", "py (==1.11.0)", "pytest (==7.2.0)", "pytest-cov (==4.0.0)", "pytest-timeout (==2.1.0)", "pyyaml (==5.1)"]
+
+[[package]]
 name = "sniffio"
 version = "1.3.0"
 description = "Sniff out which async library your code is running under"
@@ -642,6 +653,10 @@ pydantic = [
 pytest = [
     {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
     {file = "pytest-7.3.1.tar.gz", hash = "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"},
+]
+python-multipart = [
+    {file = "python_multipart-0.0.6-py3-none-any.whl", hash = "sha256:ee698bab5ef148b0a760751c261902cd096e57e10558e11aca17646b74ee1c18"},
+    {file = "python_multipart-0.0.6.tar.gz", hash = "sha256:e9925a80bb668529f1b67c7fdb0a5dacdd7cbfc6fb0bff3ea443fe22bdd62132"},
 ]
 sniffio = [
     {file = "sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ optional = true
 [tool.poetry.group.test.dependencies]
 httpx = "^0.24.1"
 pytest = "^7.3.1"
+python-multipart = "^0.0.6"
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers --tb=short -s"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -41,8 +41,15 @@ def test_client() -> TestClient:
         return response
 
     @app.get("/protected", response_class=JSONResponse)
-    async def protected(request: Request, csrf_protect: CsrfProtect = Depends()):
-        await csrf_protect.validate_csrf(request)
+    def protected(request: Request, csrf_protect: CsrfProtect = Depends()):
+        csrf_protect.validate_csrf(request)
+        response: JSONResponse = JSONResponse(status_code=200, content={"detail": "OK"})
+        csrf_protect.unset_csrf_cookie(response)  # prevent token reuse
+        return response
+
+    @app.post("/form", response_class=JSONResponse)
+    def form(request: Request, csrf_protect: CsrfProtect = Depends()):
+        csrf_protect.validate_csrf(request)
         response: JSONResponse = JSONResponse(status_code=200, content={"detail": "OK"})
         csrf_protect.unset_csrf_cookie(response)  # prevent token reuse
         return response

--- a/tests/form_field_token.py
+++ b/tests/form_field_token.py
@@ -1,0 +1,33 @@
+### Third-Party Packages ###
+from . import test_client
+from fastapi.testclient import TestClient
+
+### Local Modules ###
+from fastapi_csrf_protect import CsrfProtect
+
+
+def test_correct_form_hidden_field_token(test_client: TestClient):
+    ### Loads Config ###
+    @CsrfProtect.load_config
+    def get_configs():
+        return [
+            ("secret_key", "secret"),
+            ("token_location", "body"),
+            ("token_key", "csrf_token"),
+        ]
+
+    ### Generate token ###
+    response = test_client.get("/gen-token")
+
+    ### Assertion ###
+    assert response.status_code == 200
+
+    ### Extract `csrf_token` from response to be set as next request's hidden form field ###
+    csrf_token: str = response.json().get("csrf_token", None)
+    
+    ### Get protected contents ###
+    response = test_client.post("/form", data={"csrf_token": csrf_token})
+    
+    ### Assertions ###
+    assert response.status_code == 200
+    assert response.json() == {"detail": "OK"}


### PR DESCRIPTION
Fix for https://github.com/aekasitt/fastapi-csrf-protect/issues/19