### PR TITLE
Update core.py

### DIFF
--- a/fastapi_csrf_protect/core.py
+++ b/fastapi_csrf_protect/core.py
@@ -225,5 +225,4 @@ class CsrfProtect(CsrfConfig):
                 token = request._form.get(self._token_key, "")
             else:
                 token = self.get_csrf_from_body(await request.body())
-        serializer = URLSafeTimedSerializer(secret_key, salt="fastapi-csrf-token")
         self.compare(signed_token, token, secret_key, time_limit)


### PR DESCRIPTION
Expose a static `CsrfProtect.compare` method for csrf validation. 
Use case: Allow using 
`websocket.cookies.get(cookie_key)`
instead of
`request.cookies.get(cookie_key)`
for extracting the signed token.